### PR TITLE
CHANGE: lambda code to dockerized lambda image

### DIFF
--- a/Dockerfile.lambda
+++ b/Dockerfile.lambda
@@ -1,0 +1,8 @@
+FROM public.ecr.aws/lambda/python:3.9
+
+# Copy function code
+COPY . ${LAMBDA_TASK_ROOT}
+RUN  pip3 install -r requirements.txt --target "${LAMBDA_TASK_ROOT}"
+
+# Set the CMD to your handler (could also be done as a parameter override outside of the Dockerfile)
+CMD [ "app/main.handler" ]

--- a/serverless.yml
+++ b/serverless.yml
@@ -2,34 +2,26 @@ service: fastapi-microservice-template
 
 frameworkVersion: "3"
 
-configValidationMode: error
-useDotenv: true
-deprecationNotificationMode: warn:summary
-
-plugins:
-    - serverless-python-requirements
-
-custom:
-    pythonRequirements:
-        dockerizePip: true
-        dockerImage: mlupin/docker-lambda:python3.9-build
-
 provider:
     name: aws
-    stage: ${opt:stage, "staging"}
-    region: us-west-2
-    runtime: python3.9
-    memorySize: 1024
+    region: ${opt:region, 'us-west-1'}
+    stage: ${opt:stage, 'dev'}
+    ecr:
+        images:
+            appimage:
+                path: ./
+                file: Dockerfile.lambda
+                platform: linux/amd64
 
     httpApi:
         cors: true
-
     environment:
         STAGE: ${self:provider.stage}
-
+    
 functions:
     app:
-        handler: app/main.handler
+        image:
+            name: appimage
         events:
             - httpApi:
                   path: "*"


### PR DESCRIPTION
code deployment have less size limit than container lambda functions. That is why I convert sls lambda function to image lambda function.